### PR TITLE
feat: add environment variable for supplying token

### DIFF
--- a/src/commands/azuredevops.ts
+++ b/src/commands/azuredevops.ts
@@ -25,7 +25,7 @@ export default class AzureDevOps extends Command {
         token: Flags.string({
             char: 't',
             description:
-                'An Azure DevOps user personal access token tied to the provided username. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for more information about the token.',
+                'An Azure DevOps user personal access token tied to the provided username. Can also be supplied with the REDSHIRTS_TOKEN environment variable. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for more information about the token.',
             required: true,
             env: 'REDSHIRTS_TOKEN',
             helpGroup: HelpGroup.AUTH,

--- a/src/commands/azuredevops.ts
+++ b/src/commands/azuredevops.ts
@@ -27,6 +27,7 @@ export default class AzureDevOps extends Command {
             description:
                 'An Azure DevOps user personal access token tied to the provided username. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for more information about the token.',
             required: true,
+            env: 'REDSHIRTS_TOKEN',
             helpGroup: HelpGroup.AUTH,
         }),
         orgs: Flags.string({

--- a/src/commands/bitbucket.ts
+++ b/src/commands/bitbucket.ts
@@ -34,6 +34,7 @@ export default class Bitbucket extends Command {
             description:
                 'A Bitbucket access token tied to the provided username. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for how to create this token.',
             required: true,
+            env: 'REDSHIRTS_TOKEN',
             helpGroup: HelpGroup.AUTH,
         }),
         workspaces: Flags.string({

--- a/src/commands/bitbucket.ts
+++ b/src/commands/bitbucket.ts
@@ -32,7 +32,7 @@ export default class Bitbucket extends Command {
         token: Flags.string({
             char: 't',
             description:
-                'A Bitbucket access token tied to the provided username. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for how to create this token.',
+                'A Bitbucket access token tied to the provided username. Can also be supplied with the REDSHIRTS_TOKEN environment variable. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for how to create this token.',
             required: true,
             env: 'REDSHIRTS_TOKEN',
             helpGroup: HelpGroup.AUTH,

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -28,6 +28,7 @@ export default class Github extends Command {
             description:
                 'Github personal access token. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for more information.',
             required: true,
+            env: 'REDSHIRTS_TOKEN',
             helpGroup: HelpGroup.AUTH,
         }),
         orgs: Flags.string({

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -26,7 +26,7 @@ export default class Github extends Command {
         token: Flags.string({
             char: 't',
             description:
-                'Github personal access token. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for more information.',
+                'Github personal access token. Can also be supplied with the REDSHIRTS_TOKEN environment variable. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for more information.',
             required: true,
             env: 'REDSHIRTS_TOKEN',
             helpGroup: HelpGroup.AUTH,

--- a/src/commands/gitlab.ts
+++ b/src/commands/gitlab.ts
@@ -21,7 +21,7 @@ export default class Gitlab extends Command {
         token: Flags.string({
             char: 't',
             description:
-                'Gitlab personal access token. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for more information about the token.',
+                'Gitlab personal access token. Can also be supplied with the REDSHIRTS_TOKEN environment variable. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for more information about the token.',
             required: true,
             env: 'REDSHIRTS_TOKEN',
             helpGroup: HelpGroup.AUTH,

--- a/src/commands/gitlab.ts
+++ b/src/commands/gitlab.ts
@@ -23,6 +23,7 @@ export default class Gitlab extends Command {
             description:
                 'Gitlab personal access token. This token must be tied to a user that has sufficient visibility of the repo(s) being counted. See the description below for more information about the token.',
             required: true,
+            env: 'REDSHIRTS_TOKEN',
             helpGroup: HelpGroup.AUTH,
         }),
         groups: Flags.string({


### PR DESCRIPTION
Adds `REDSHIRTS_TOKEN` as an env var option for the `--token` flag.