### PR TITLE
fix: ignore duplicate repos

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -148,7 +148,7 @@ export const getExplicitRepoList = (
     const addedRepos: Repo[] = [];
 
     for (const repo of explicitRepos) {
-        if (repos.some((r) => repoMatches(r, repo))) {
+        if (repos.some((r) => repoMatches(r, repo)) || addedRepos.some((r) => repoMatches(r, repo))) {
             LOGGER.debug(
                 `Skipping adding ${sourceInfo.repoTerm} ${repo.owner}/${repo.name} as we already got it from the ${sourceInfo.orgTerm}`
             );

--- a/test/common/utils.test.ts
+++ b/test/common/utils.test.ts
@@ -1,7 +1,15 @@
-import { Flags } from "@oclif/core";
-import { expect } from "chai";
-import { Protocol, Repo } from "../../src/common/types";
-import { deleteFlagKey, getRepoListFromParams, getServerUrl, repoMatches, splitAndCombine, splitRepos } from '../../src/common/utils';
+import { Flags } from '@oclif/core';
+import { expect } from 'chai';
+import { Protocol, Repo, SourceType, VcsSourceInfo } from '../../src/common/types';
+import {
+    deleteFlagKey,
+    getExplicitRepoList,
+    getRepoListFromParams,
+    getServerUrl,
+    repoMatches,
+    splitAndCombine,
+    splitRepos,
+} from '../../src/common/utils';
 
 describe('utils', () => {
     it('parses the CSV repo list correctly', () => {
@@ -9,16 +17,16 @@ describe('utils', () => {
         expect(repos).to.have.deep.members([
             {
                 owner: 'org',
-                name: 'repo1'
+                name: 'repo1',
             },
             {
                 owner: 'org',
-                name: 'repo2'
+                name: 'repo2',
             },
             {
                 owner: 'org2/group',
-                name: 'repo3'
-            }
+                name: 'repo3',
+            },
         ]);
     });
 
@@ -30,19 +38,19 @@ describe('utils', () => {
         const repo1: Repo = {
             owner: 'owner',
             name: 'name',
-            private: true
+            private: true,
         };
 
         const repo2: Repo = {
             owner: 'owner',
             name: 'name',
-            private: false
+            private: false,
         };
 
         const repo3: Repo = {
             owner: 'other',
             name: 'name',
-            private: true
+            private: true,
         };
 
         expect(repoMatches(repo1, repo2)).to.be.true;
@@ -51,41 +59,79 @@ describe('utils', () => {
 
     it('gets a repo list from a string or file', () => {
         expect(getRepoListFromParams(2, 2)).to.have.length(0);
-        expect(getRepoListFromParams(2, 2, 'org1/repo1,org2/repo2')).to.have.deep.members(
-            [
+        expect(getRepoListFromParams(2, 2, 'org1/repo1,org2/repo2'))
+            .to.have.deep.members([
                 {
-                    owner: "org1",
-                    name: "repo1"
+                    owner: 'org1',
+                    name: 'repo1',
                 },
                 {
-                    owner: "org2",
-                    name: "repo2"
-                }
-            ]).and.to.have.length(2);
+                    owner: 'org2',
+                    name: 'repo2',
+                },
+            ])
+            .and.to.have.length(2);
 
-        expect(getRepoListFromParams(2, 2, undefined, 'test/resources/repos1.txt')).to.have.deep.members(
-            [
+        expect(getRepoListFromParams(2, 2, undefined, 'test/resources/repos1.txt'))
+            .to.have.deep.members([
                 {
-                    owner: "org1",
-                    name: "repo1"
+                    owner: 'org1',
+                    name: 'repo1',
                 },
                 {
-                    owner: "org2222",
-                    name: "repo2222"
-                }
-            ]).and.to.have.length(2);
+                    owner: 'org2222',
+                    name: 'repo2222',
+                },
+            ])
+            .and.to.have.length(2);
 
-        expect(getRepoListFromParams(2, 2, 'org1/repo1,org2/repo2', 'test/resources/repos1.txt')).to.have.deep.members(
-            [
+        expect(getRepoListFromParams(2, 2, 'org1/repo1,org2/repo2', 'test/resources/repos1.txt'))
+            .to.have.deep.members([
                 {
-                    owner: "org1",
-                    name: "repo1"
+                    owner: 'org1',
+                    name: 'repo1',
                 },
                 {
-                    owner: "org2",
-                    name: "repo2"
-                }
-            ]).and.to.have.length(2);
+                    owner: 'org2',
+                    name: 'repo2',
+                },
+            ])
+            .and.to.have.length(2);
+    });
+
+    it('only adds unique repos to the repos list', () => {
+        const sourceInfo: VcsSourceInfo = {
+            url: 'example.com',
+            token: 'xxx',
+            minPathLength: 2,
+            maxPathLength: 2,
+            orgFlagName: '',
+            includePublic: false,
+            requiresEnrichment: false,
+            sourceType: SourceType.Github,
+            repoTerm: '',
+            orgTerm: '',
+        };
+        const reposList: Repo[] = [
+            { name: 'repo1', owner: 'org1' },
+            { name: 'repo3', owner: 'org3' },
+        ];
+        expect(getExplicitRepoList(sourceInfo, reposList, 'org1/repo1,org2/repo2', 'test/resources/repos1.txt'))
+            .to.have.deep.members([
+                {
+                    owner: 'org2',
+                    name: 'repo2',
+                },
+            ])
+            .and.to.have.length(1);
+        expect(getExplicitRepoList(sourceInfo, [], 'org1/repo1,org1/repo1,org1/repo1'))
+            .to.have.deep.members([
+                {
+                    owner: 'org1',
+                    name: 'repo1',
+                },
+            ])
+            .and.to.have.length(1);
     });
 
     it('splits and combines', () => {
@@ -95,20 +141,19 @@ describe('utils', () => {
     });
 
     it('deletes a key', () => {
-
         const flags = {
             a: Flags.integer(),
             b: Flags.integer(),
-            c: Flags.integer()
+            c: Flags.integer(),
         };
 
         const newFlags = deleteFlagKey(flags, 'b', 'c', 'd');
-        expect(newFlags).to.deep.equal({a: Flags.integer()});
+        expect(newFlags).to.deep.equal({ a: Flags.integer() });
         // flags is unmodified
         expect(flags).to.deep.equal({
             a: Flags.integer(),
             b: Flags.integer(),
-            c: Flags.integer()
+            c: Flags.integer(),
         });
     });
 


### PR DESCRIPTION
if a repo is specified multiple times in the `--repos` flag, it is ignored and not returned by the `getExplicitRepoList` method. 