### PR TITLE
fix: fix env var name for logging API responses

### DIFF
--- a/src/common/api-manager.ts
+++ b/src/common/api-manager.ts
@@ -1,6 +1,6 @@
 import { Repo, SourceInfo, VCSCommit } from './types';
 
-export const LOG_API_RESPONSES_ENV = 'REDSHIRT_LOG_API_RESPONSES';
+export const LOG_API_RESPONSES_ENV = 'REDSHIRTS_LOG_API_RESPONSES';
 export abstract class ApiManager {
     sourceInfo: SourceInfo;
     logApiResponses: boolean;


### PR DESCRIPTION
Fixes a missing S in the environment variable for verbose API logging