### PR TITLE
Feat: Add bitbucket server bearer token auth and no-cert-verify flag

### DIFF
--- a/src/commands/azuredevops.ts
+++ b/src/commands/azuredevops.ts
@@ -57,7 +57,7 @@ export default class AzureDevOps extends Command {
 
         const sourceInfo = AzureDevOps.getSourceInfo(':' + flags.token, flags['include-public']);
 
-        const apiManager = new AzureApiManager(sourceInfo, flags['ca-cert']);
+        const apiManager = new AzureApiManager(sourceInfo, flags['ca-cert'], flags['no-cert-verify']);
         const runner = new AzureRunner(sourceInfo, flags, apiManager);
 
         if (!(flags.orgs || flags.projects || flags.repos || flags['repo-file'])) {

--- a/src/commands/bitbucket-server.ts
+++ b/src/commands/bitbucket-server.ts
@@ -1,13 +1,15 @@
-import { Flags } from '@oclif/core';
+import { Command, Flags } from '@oclif/core';
 import { vcsServerFlags } from '../common/flags';
 import { MAX_REQUESTS_PER_SECOND_VAR } from '../common/throttled-vcs-api-manager';
-import { HelpGroup, SourceType, VcsSourceInfo } from '../common/types';
+import { HelpGroup, SourceType } from '../common/types';
 import { deleteFlagKey, getServerUrl, init } from '../common/utils';
 import { BitbucketServerApiManager } from '../vcs/bitbucketServer/bitbucket-server-api-manager';
 import { BitbucketServerRunner } from '../vcs/bitbucketServer/bitbucket-server-runner';
 import Bitbucket from './bitbucket';
+import { BitbucketServerVcsSourceInfo } from '../vcs/bitbucketServer/bitbucket-server-types';
 
-export default class BitbucketServer extends Bitbucket {
+// do not extend Bitbucket command, because we do not want to inherit all of the flags (workspaces is not relevant)
+export default class BitbucketServer extends Command {
     static summary = 'Count active contributors for Bitbucket server (self-hosted) repos';
 
     static description = `This tool works with Bitbucket server v1 APIs.
@@ -20,8 +22,8 @@ export default class BitbucketServer extends Bitbucket {
     If you run this tool multiple times in quick succession, or if there are other external consumers of this rate limit, you may need to provide a lower value here, because there is no way to check the rate limit status in a stateless way. For Bitbucket Server, you can also control throttling by setting the ${MAX_REQUESTS_PER_SECOND_VAR} environment variable. This will cause the tool to submit no more than that many requests per second from the start of execution. This will slow down execution but avoid unexpected rate limit issues.`;
 
     static examples = [
-        `$ <%= config.bin %> <%= command.id %> --token ATXXX --repos bridgecrewio/checkov,try-bridgecrew/terragoat --hostname github.mycompany.internal`,
-        `$ <%= config.bin %> <%= command.id %> --token ATXXX --workspaces bridgecrewio,try-bridgecrew --hostname github.mycompany.internal --port 9999`,
+        `$ <%= config.bin %> <%= command.id %> --username myuser --token ATXXX --repos bridgecrewio/checkov,try-bridgecrew/terragoat --hostname bitbucket.mycompany.internal`,
+        `$ <%= config.bin %> <%= command.id %> --token ATXXX --projects bridgecrewio,try-bridgecrew --hostname bitbucket.mycompany.internal --port 9999`,
     ];
 
     // we can reuse most of the Bitbucket args, but `workspaces` is not relevant, so we can do this fun thing
@@ -33,7 +35,14 @@ export default class BitbucketServer extends Bitbucket {
             required: false,
             helpGroup: HelpGroup.REPO_SPEC,
         }),
-        ...deleteFlagKey(Bitbucket.flags, 'workspaces'),
+        ...deleteFlagKey(Bitbucket.flags, 'workspaces', 'username'),
+        username: Flags.string({
+            description:
+                'Your Bitbucket username associated with the provided app token. If provided, then Redshirts will use Basic authentication with this username and token. If omitted, then Redshirts will use Bearer auth with the provided token.',
+            char: 'u',
+            required: false,
+            helpGroup: HelpGroup.AUTH,
+        }),
     } as any;
 
     async run(): Promise<void> {
@@ -42,13 +51,14 @@ export default class BitbucketServer extends Bitbucket {
 
         const serverUrl = getServerUrl(flags.hostname, flags.port, flags.protocol);
         const baseUrl = `${serverUrl}/rest/api/1.0`;
-        const sourceInfo = BitbucketServer.getSourceInfo(
-            `${flags.username}:${flags.token}`,
-            flags['include-public'],
-            baseUrl
-        );
+        const sourceInfo = BitbucketServer.getSourceInfo(flags.token, flags['include-public'], baseUrl, flags.username);
 
-        const apiManager = new BitbucketServerApiManager(sourceInfo, flags['ca-cert']);
+        const apiManager = new BitbucketServerApiManager(
+            sourceInfo,
+            flags['requests-per-hour'],
+            flags['ca-cert'],
+            flags['no-cert-verify']
+        );
         const runner = new BitbucketServerRunner(sourceInfo, flags, apiManager);
 
         await runner.execute();
@@ -58,11 +68,13 @@ export default class BitbucketServer extends Bitbucket {
         token: string,
         includePublic: boolean,
         url: string,
+        username?: string,
         sourceType = SourceType.BitbucketServer
-    ): VcsSourceInfo {
+    ): BitbucketServerVcsSourceInfo {
         return {
             sourceType,
             url,
+            username,
             token,
             repoTerm: 'repo',
             orgTerm: 'project',

--- a/src/commands/bitbucket.ts
+++ b/src/commands/bitbucket.ts
@@ -53,7 +53,12 @@ export default class Bitbucket extends Command {
 
         const sourceInfo = Bitbucket.getSourceInfo(`${flags.username}:${flags.token}`, flags['include-public']);
 
-        const apiManager = new BitbucketApiManager(sourceInfo, flags['requests-per-hour'], flags['ca-cert']);
+        const apiManager = new BitbucketApiManager(
+            sourceInfo,
+            flags['requests-per-hour'],
+            flags['ca-cert'],
+            flags['no-cert-verify']
+        );
         const runner = new BitbucketRunner(sourceInfo, flags, apiManager);
 
         await runner.execute();

--- a/src/commands/github-server.ts
+++ b/src/commands/github-server.ts
@@ -32,7 +32,7 @@ export default class GithubServer extends Github {
         const baseUrl = `${serverUrl}/api/v3`;
         const sourceInfo = Github.getSourceInfo(flags.token, flags['include-public'], baseUrl, SourceType.GithubServer);
 
-        const apiManager = new GithubServerApiManager(sourceInfo, flags['ca-cert']);
+        const apiManager = new GithubServerApiManager(sourceInfo, flags['ca-cert'], flags['no-cert-verify']);
         const runner = new GithubServerRunner(sourceInfo, flags, apiManager);
 
         await runner.execute();

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -45,7 +45,7 @@ export default class Github extends Command {
         init(flags, this.config);
         const sourceInfo = Github.getSourceInfo(flags.token, flags['include-public']);
 
-        const apiManager = new GithubApiManager(sourceInfo, flags['ca-cert']);
+        const apiManager = new GithubApiManager(sourceInfo, flags['ca-cert'], flags['no-cert-verify']);
         const runner = new GithubRunner(sourceInfo, flags, apiManager);
 
         await runner.execute();

--- a/src/commands/gitlab-server.ts
+++ b/src/commands/gitlab-server.ts
@@ -33,7 +33,7 @@ export default class GitlabServer extends Gitlab {
 
         const sourceInfo = Gitlab.getSourceInfo(flags.token, flags['include-public'], baseUrl, SourceType.GitlabServer);
 
-        const apiManager = new GitlabServerApiManager(sourceInfo, flags['ca-cert']);
+        const apiManager = new GitlabServerApiManager(sourceInfo, flags['ca-cert'], flags['no-cert-verify']);
         const runner = new GitlabServerRunner(sourceInfo, flags, apiManager);
 
         await runner.execute();

--- a/src/commands/gitlab.ts
+++ b/src/commands/gitlab.ts
@@ -41,7 +41,7 @@ export default class Gitlab extends Command {
 
         const sourceInfo = Gitlab.getSourceInfo(flags.token, flags['include-public']);
 
-        const apiManager = new GitlabApiManager(sourceInfo, flags['ca-cert']);
+        const apiManager = new GitlabApiManager(sourceInfo, flags['ca-cert'], flags['no-cert-verify']);
         const runner = new GitlabRunner(sourceInfo, flags, apiManager);
 
         await runner.execute();

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -47,7 +47,7 @@ export default class Local extends Command {
             aliases: ['skip-dir-file'],
             helpGroup: HelpGroup.REPO_SPEC,
         }),
-        ...deleteFlagKey(commonFlags, 'include-public', 'ca-cert'),
+        ...deleteFlagKey(commonFlags, 'include-public', 'ca-cert', 'no-cert-verify'),
     };
 
     async run(): Promise<void> {

--- a/src/common/flags.ts
+++ b/src/common/flags.ts
@@ -19,6 +19,11 @@ export const commonFlags = {
         required: false,
         helpGroup: HelpGroup.CONNECTION,
     }),
+    'no-cert-verify': Flags.boolean({
+        description:
+            'Bypass SSL verification on HTTPS requests. WARNING: This is inherently dangerous and can expose your data, including API tokens, in the event that your network path is compromised.',
+        helpGroup: HelpGroup.CONNECTION,
+    }),
     days: Flags.integer({
         description:
             'The number of days for which to fetch commit history. Defaults to 90, which is the value used in the Prisma Cloud platform. It is not recommended to change this except for experimentation purposes.',

--- a/src/common/rate-limit-vcs-api-manager.ts
+++ b/src/common/rate-limit-vcs-api-manager.ts
@@ -1,7 +1,6 @@
-import { AxiosError, AxiosRequestConfig, AxiosResponse, RawAxiosRequestHeaders } from 'axios';
+import { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { RateLimitStatus, RepoResponse, VcsSourceInfo } from './types';
 import { getEnvVarWithDefault, LOGGER, sleepUntilDateTime } from './utils';
-import https = require('https');
 import { VcsApiManager } from './vcs-api-manager';
 
 const REQUESTS_REMAINING_BUFFER_ENV_VAR = 'REDSHIRTS_REQUESTS_REMAINING_BUFFER';
@@ -18,9 +17,10 @@ export abstract class RateLimitVcsApiManager extends VcsApiManager {
         rateLimitRemainingHeader: string,
         rateLimitResetHeader: string,
         rateLimitEndpoint?: string,
-        certPath?: string
+        certPath?: string,
+        noCertVerify = false
     ) {
-        super(sourceInfo, certPath);
+        super(sourceInfo, certPath, noCertVerify);
         this.rateLimitRemainingHeader = rateLimitRemainingHeader;
         this.rateLimitResetHeader = rateLimitResetHeader;
         this.rateLimitEndpoint = rateLimitEndpoint;
@@ -29,19 +29,6 @@ export abstract class RateLimitVcsApiManager extends VcsApiManager {
             getEnvVarWithDefault(REQUESTS_REMAINING_BUFFER_ENV_VAR, DEFAULT_REQUESTS_REMAINING_BUFFER)
         );
         LOGGER.debug(`Request remaining buffer: ${this.requestRemainingBuffer}`);
-    }
-
-    _buildAxiosConfiguration(baseURL: string, headers?: RawAxiosRequestHeaders): AxiosRequestConfig {
-        return this.cert
-            ? {
-                  baseURL,
-                  headers,
-                  httpsAgent: new https.Agent({ ca: this.cert }),
-              }
-            : {
-                  baseURL,
-                  headers,
-              };
     }
 
     abstract _getAxiosConfiguration(): any;

--- a/src/vcs/azure/azure-api-manager.ts
+++ b/src/vcs/azure/azure-api-manager.ts
@@ -10,8 +10,8 @@ const RATE_LIMIT_REMAINING_HEADER = 'x-ratelimit-remaining';
 const RATE_LIMIT_RESET_HEADER = 'x-ratelimit-reset';
 
 export class AzureApiManager extends RateLimitVcsApiManager {
-    constructor(sourceInfo: VcsSourceInfo, certPath?: string) {
-        super(sourceInfo, RATE_LIMIT_REMAINING_HEADER, RATE_LIMIT_RESET_HEADER, undefined, certPath);
+    constructor(sourceInfo: VcsSourceInfo, certPath?: string, noCertVerify = false) {
+        super(sourceInfo, RATE_LIMIT_REMAINING_HEADER, RATE_LIMIT_RESET_HEADER, undefined, certPath, noCertVerify);
     }
 
     getUserRepos(): Promise<RepoResponse[]> {

--- a/src/vcs/bitbucketServer/bitbucket-server-types.ts
+++ b/src/vcs/bitbucketServer/bitbucket-server-types.ts
@@ -1,4 +1,9 @@
+import { VcsSourceInfo } from '../../common/types';
 import { BitbucketAuthor, BitbucketCommit, BitbucketRepoResponse } from '../bitbucket/bitbucket-types';
+
+export interface BitbucketServerVcsSourceInfo extends VcsSourceInfo {
+    username?: string;
+}
 
 export interface BitbucketServerAuthor extends BitbucketAuthor {
     name: string;

--- a/src/vcs/github/github-api-manager.ts
+++ b/src/vcs/github/github-api-manager.ts
@@ -10,8 +10,15 @@ const RATE_LIMIT_REMAINING_HEADER = 'x-ratelimit-remaining';
 const RATE_LIMIT_RESET_HEADER = 'x-ratelimit-reset';
 const RATE_LIMIT_ENDPOINT = 'rate_limit';
 export class GithubApiManager extends RateLimitVcsApiManager {
-    constructor(sourceInfo: VcsSourceInfo, certPath?: string) {
-        super(sourceInfo, RATE_LIMIT_REMAINING_HEADER, RATE_LIMIT_RESET_HEADER, RATE_LIMIT_ENDPOINT, certPath);
+    constructor(sourceInfo: VcsSourceInfo, certPath?: string, noCertVerify = false) {
+        super(
+            sourceInfo,
+            RATE_LIMIT_REMAINING_HEADER,
+            RATE_LIMIT_RESET_HEADER,
+            RATE_LIMIT_ENDPOINT,
+            certPath,
+            noCertVerify
+        );
     }
 
     _getAxiosConfiguration(): AxiosRequestConfig {

--- a/src/vcs/gitlab/gitlab-api-manager.ts
+++ b/src/vcs/gitlab/gitlab-api-manager.ts
@@ -11,8 +11,15 @@ const RATE_LIMIT_RESET_HEADER = 'ratelimit-reset';
 const RATE_LIMIT_ENDPOINT = 'user';
 
 export class GitlabApiManager extends RateLimitVcsApiManager {
-    constructor(sourceInfo: VcsSourceInfo, certPath?: string) {
-        super(sourceInfo, RATE_LIMIT_REMAINING_HEADER, RATE_LIMIT_RESET_HEADER, RATE_LIMIT_ENDPOINT, certPath);
+    constructor(sourceInfo: VcsSourceInfo, certPath?: string, noCertVerify = false) {
+        super(
+            sourceInfo,
+            RATE_LIMIT_REMAINING_HEADER,
+            RATE_LIMIT_RESET_HEADER,
+            RATE_LIMIT_ENDPOINT,
+            certPath,
+            noCertVerify
+        );
     }
 
     _getAxiosConfiguration(): AxiosRequestConfig {


### PR DESCRIPTION
Adds the option to omit the username for BB server and use bearer auth instead of basic auth

https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html

Also adds a no-cert-verify flag with appropriate warnings